### PR TITLE
Support Part Studio configuration selection

### DIFF
--- a/resources/qml/DocumentCard.qml
+++ b/resources/qml/DocumentCard.qml
@@ -27,12 +27,19 @@ MouseArea
 
         return width
     }
-    implicitHeight: UM.Theme.getSize("card_icon").height * iconSizeFactor + 2 * UM.Theme.getSize("default_margin").height
+    implicitHeight: Math.max(UM.Theme.getSize("card_icon").height * iconSizeFactor,
+                             configurationColumn.visible ? configurationColumn.implicitHeight : 0)
+                    + 2 * UM.Theme.getSize("default_margin").height
 
     hoverEnabled: true
     enabled: modelData.hasChildren || modelData.isDownloadable // Should actually always be true...
     onClicked:
     {
+        if(isInside(configurationColumn, mouse.x, mouse.y) || isInside(checkBoxSelected, mouse.x, mouse.y))
+        {
+            return
+        }
+
         if(modelData.hasChildren)
         {
             documentsListStack.push("DocumentsView.qml", {"documentsModel": modelData.childModel})
@@ -82,8 +89,47 @@ MouseArea
 
             ColumnLayout
             {
+                id: configurationColumn
+                visible: modelData.hasConfigurationParameters
+                Layout.preferredWidth: Math.min(430, Math.max(300, root.width * 0.42))
+                Layout.rightMargin: UM.Theme.getSize("default_margin").width
+                Layout.alignment: Qt.AlignVCenter
+                spacing: UM.Theme.getSize("narrow_margin").height
+
+                Repeater
+                {
+                    model: modelData.configurationParameters
+
+                    ColumnLayout
+                    {
+                        Layout.fillWidth: true
+                        spacing: UM.Theme.getSize("narrow_margin").height
+
+                        UM.Label
+                        {
+                            Layout.fillWidth: true
+                            text: modelData.name
+                            font: UM.Theme.getFont("small")
+                            elide: Text.ElideRight
+                        }
+
+                        ComboBox
+                        {
+                            Layout.fillWidth: true
+                            model: modelData.options
+                            textRole: "name"
+                            currentIndex: modelData.selectedIndex
+                            onActivated: modelData.selectedIndex = index
+                        }
+                    }
+                }
+            }
+
+            ColumnLayout
+            {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
+                Layout.minimumWidth: 140
 
                 spacing: UM.Theme.getSize("narrow_margin").width
 
@@ -123,18 +169,23 @@ MouseArea
                     }
                 }
             }
-        }
 
-        UM.CheckBox
-        {
-            id: checkBoxSelected
-            anchors.right: parent.right
-            anchors.verticalCenter: parent.verticalCenter
-            anchors.margins: UM.Theme.getSize("default_margin").height
-            visible: modelData.isDownloadable
-            text: catalog.i18nc("@action:button", "Add to selection")
-            checked: modelData.selected
-            onCheckedChanged: modelData.selected = checked
+            UM.CheckBox
+            {
+                id: checkBoxSelected
+                visible: modelData.isDownloadable
+                Layout.alignment: Qt.AlignVCenter
+                Layout.preferredWidth: 130
+                text: catalog.i18nc("@action:button", "Add to selection")
+                checked: modelData.selected
+                onClicked: modelData.selected = checked
+            }
         }
+    }
+
+    function isInside(item, x, y)
+    {
+        var point = item.mapFromItem(root, x, y)
+        return item.visible && point.x >= 0 && point.x <= item.width && point.y >= 0 && point.y <= item.height
     }
 }

--- a/src/OnshapeController.py
+++ b/src/OnshapeController.py
@@ -126,6 +126,7 @@ class OnshapeController(QObject):
                                     first_element.workspace_id,
                                     first_element.tab_id,
                                     [element.id for element in elements],
+                                    first_element.configuration,
                                     functools.partial(OnshapeController._onMeshDownloadProgress, message),
                                     functools.partial(self._onMeshDownloaded, message, first_element.name),
                                     functools.partial(OnshapeController._onMeshDownloadError, message))

--- a/src/api/OnshapeApi.py
+++ b/src/api/OnshapeApi.py
@@ -5,7 +5,7 @@ import tempfile
 
 from PyQt6.QtCore import QObject, pyqtSlot, QUrlQuery, QUrl
 
-from typing import Callable, List, TYPE_CHECKING
+from typing import Callable, List, Optional, TYPE_CHECKING
 
 from UM.Application import Application
 from UM.TaskManagement.HttpRequestManager import HttpRequestManager
@@ -167,6 +167,7 @@ class OnshapeApi(QObject):
                   document_id: str,
                   workspace_id: str,
                   tab_id: str,
+                  configuration: Optional[str],
                   on_finished: Callable[[List['DocumentsTreeNode']], None],
                   on_error: Callable[['QNetworkReply', 'QNetworkReply.NetworkError'], None]) -> None:
         """Lists the available parts in the given tab"""
@@ -175,7 +176,7 @@ class OnshapeApi(QObject):
             data_json = json.loads(bytes(reply.readAll()).decode())
 
             for part_data in data_json:
-                parts.append(DocumentsTreeNode(Part(part_data, document_id, workspace_id, tab_id)))
+                parts.append(DocumentsTreeNode(Part(part_data, document_id, workspace_id, tab_id, configuration)))
 
             on_finished(parts)
 
@@ -184,7 +185,27 @@ class OnshapeApi(QObject):
         query = QUrlQuery()
         query.addQueryItem('withThumbnails', 'true')
         query.addQueryItem('includeFlatParts', 'false')
+        if configuration is not None and len(configuration) > 0:
+            query.addQueryItem('configuration', configuration)
         url.setQuery(query)
+
+        self._http.get(url,
+                       scope = self._json_scope,
+                       callback = response_received,
+                       error_callback = on_error,
+                       timeout = self.DEFAULT_REQUEST_TIMEOUT)
+
+    def getConfiguration(self,
+                         document_id: str,
+                         workspace_id: str,
+                         tab_id: str,
+                         on_finished: Callable[[dict], None],
+                         on_error: Callable[['QNetworkReply', 'QNetworkReply.NetworkError'], None]) -> None:
+        """Retrieves the configuration metadata for the given tab"""
+        def response_received(reply: 'QNetworkReply'):
+            on_finished(json.loads(bytes(reply.readAll()).decode()))
+
+        url = f'{self.API_ROOT}/elements/d/{document_id}/w/{workspace_id}/e/{tab_id}/configuration'
 
         self._http.get(url,
                        scope = self._json_scope,
@@ -211,6 +232,7 @@ class OnshapeApi(QObject):
                       workspace_id: str,
                       tab_id: str,
                       parts_ids: List[str],
+                      configuration: Optional[str],
                       on_progress: Callable[[int, int], None],
                       on_finished: Callable[[str], None],
                       on_error: Callable[['QNetworkReply', 'QNetworkReply.NetworkError'], None]) -> None:
@@ -231,6 +253,8 @@ class OnshapeApi(QObject):
         query.addQueryItem('partIds', ','.join(parts_ids))
         query.addQueryItem('units', 'millimeter')
         query.addQueryItem('mode', 'binary')
+        if configuration is not None and len(configuration) > 0:
+            query.addQueryItem('configuration', configuration)
 
         resolution = Application.getInstance().getPreferences().getValue('plugin_onshape/tesselation_resolution')
         if resolution == 'coarse':

--- a/src/data/BaseElement.py
+++ b/src/data/BaseElement.py
@@ -61,24 +61,37 @@ class BaseElement:
 
     def loadChildren(self,
                      api: 'OnshapeApi',
+                     configuration: Optional[str],
                      on_finished: Callable[[List['DocumentsTreeNode']], None],
                      on_error: Callable[['QNetworkReply', 'QNetworkReply.NetworkError'], None]) -> None:
         """Starts loading the children of the current object, and immediatly start loading the child
            in case there is a single one and we allow for shortcutting"""
         def shortcut_callback(children: List['DocumentsTreeNode']):
-            if len(children) == 1:
-                children[0].element.loadChildren(api, on_finished, on_error)
+            if len(children) == 1 and not children[0].element.supports_configuration:
+                children[0].element.loadChildren(api, configuration, on_finished, on_error)
             else:
                 on_finished(children)
 
-        self._loadChildren(api, shortcut_callback if self._allow_single_child_shortcut else on_finished, on_error)
+        self._loadChildren(api, configuration, shortcut_callback if self._allow_single_child_shortcut else on_finished, on_error)
 
     def _loadChildren(self,
                       api: 'OnshapeApi',
+                      configuration: Optional[str],
                       on_finished: Callable[[List['DocumentsTreeNode']], None],
                       on_error: Callable[['QNetworkReply', 'QNetworkReply.NetworkError'], None]) -> None:
         """Method to be overridden by child classes to actually start loading the children"""
         return NotImplementedError(f'Children of {self.__class__} are not to be loaded')
+
+    @property
+    def supports_configuration(self) -> bool:
+        return False
+
+    def loadConfiguration(self,
+                          api: 'OnshapeApi',
+                          on_finished: Callable[[Dict[str, Any]], None],
+                          on_error: Callable[['QNetworkReply', 'QNetworkReply.NetworkError'], None]) -> None:
+        """Method to be overridden by child classes that support Onshape configurations"""
+        on_finished({})
 
     def hasThumbnail(self) -> bool:
         return self.thumbnail_url is not None

--- a/src/data/Document.py
+++ b/src/data/Document.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Erwan MATHIEU
 
-from typing import TYPE_CHECKING, Dict, Any, Callable, List
+from typing import TYPE_CHECKING, Dict, Any, Callable, List, Optional
 
 from .StorageElement import StorageElement
 
@@ -19,6 +19,7 @@ class Document(StorageElement):
 
     def _loadChildren(self,
                       api: 'OnshapeApi',
+                      configuration: Optional[str],
                       on_finished: Callable[[List['DocumentsTreeNode']], None],
                       on_error: Callable[['QNetworkReply', 'QNetworkReply.NetworkError'], None]) -> None:
         api.listWorkspaces(self.id, on_finished, on_error)

--- a/src/data/Part.py
+++ b/src/data/Part.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Erwan MATHIEU
 
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 from .BaseElement import BaseElement
 
@@ -8,7 +8,7 @@ from .BaseElement import BaseElement
 class Part(BaseElement):
     """Represents a part that can be loaded to be buildplate"""
 
-    def __init__(self, data: Dict[str, Any], document_id: str, workspace_id: str, tab_id: str):
+    def __init__(self, data: Dict[str, Any], document_id: str, workspace_id: str, tab_id: str, configuration: Optional[str]):
         super().__init__(name = data['name'],
                          id = data['partId'],
                          thumbnail_url = self._findThumbnailUrl(data['thumbnailInfo']['sizes']),
@@ -17,3 +17,4 @@ class Part(BaseElement):
         self.document_id: str = document_id
         self.workspace_id: str = workspace_id
         self.tab_id: str = tab_id
+        self.configuration: Optional[str] = configuration

--- a/src/data/Root.py
+++ b/src/data/Root.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Erwan MATHIEU
 
-from typing import TYPE_CHECKING, Callable, List
+from typing import TYPE_CHECKING, Callable, List, Optional
 
 from .BaseElement import BaseElement
 
@@ -18,6 +18,7 @@ class Root(BaseElement):
 
     def _loadChildren(self,
                       api: 'OnshapeApi',
+                      configuration: Optional[str],
                       on_finished: Callable[[List['DocumentsTreeNode']], None],
                       on_error: Callable[['QNetworkReply', 'QNetworkReply.NetworkError'], None]) -> None:
         api.listDocuments(on_finished, on_error)

--- a/src/data/Tab.py
+++ b/src/data/Tab.py
@@ -22,6 +22,17 @@ class Tab(BaseElement):
 
     def _loadChildren(self,
                       api: 'OnshapeApi',
+                      configuration: str,
                       on_finished: Callable[[List['DocumentsTreeNode']], None],
                       on_error: Callable[['QNetworkReply', 'QNetworkReply.NetworkError'], None]) -> None:
-        api.listParts(self._document_id, self._workspace_id, self.id, on_finished, on_error)
+        api.listParts(self._document_id, self._workspace_id, self.id, configuration, on_finished, on_error)
+
+    @property
+    def supports_configuration(self) -> bool:
+        return True
+
+    def loadConfiguration(self,
+                          api: 'OnshapeApi',
+                          on_finished: Callable[[Dict[str, Any]], None],
+                          on_error: Callable[['QNetworkReply', 'QNetworkReply.NetworkError'], None]) -> None:
+        api.getConfiguration(self._document_id, self._workspace_id, self.id, on_finished, on_error)

--- a/src/data/Workspace.py
+++ b/src/data/Workspace.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Erwan MATHIEU
 
-from typing import TYPE_CHECKING, Callable, List, Dict, Any
+from typing import TYPE_CHECKING, Callable, List, Dict, Any, Optional
 
 from datetime import datetime
 import os
@@ -36,6 +36,7 @@ class Workspace(BaseElement):
 
     def _loadChildren(self,
                       api: 'OnshapeApi',
+                      configuration: Optional[str],
                       on_finished: Callable[[List['DocumentsTreeNode']], None],
                       on_error: Callable[['QNetworkReply', 'QNetworkReply.NetworkError'], None]):
         api.listTabs(self._document_id, self.id, on_finished, on_error)

--- a/src/model/ConfigurationParameter.py
+++ b/src/model/ConfigurationParameter.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2023 Erwan MATHIEU
+
+from typing import Any, Dict, List, Optional
+
+from PyQt6.QtCore import QObject, pyqtProperty, pyqtSignal
+
+
+class ConfigurationOption(QObject):
+    """Represents one selectable value for an Onshape configuration input"""
+
+    def __init__(self, name: str, value: str):
+        super().__init__(parent = None)
+        self._name = name
+        self._value = value
+
+    @pyqtProperty(str, constant = True)
+    def name(self) -> str:
+        return self._name
+
+    @pyqtProperty(str, constant = True)
+    def value(self) -> str:
+        return self._value
+
+
+class ConfigurationParameter(QObject):
+    """Represents one Onshape configuration input exposed to QML"""
+
+    def __init__(self, data: Dict[str, Any], current_value: Optional[str]):
+        super().__init__(parent = None)
+        self._parameter_id = data['parameterId']
+        self._name = data.get('parameterName', self._parameter_id)
+        self._options = [
+            ConfigurationOption(option.get('optionName', option['option']), option['option'])
+            for option in data.get('options', [])
+        ]
+
+        selected_value = current_value or data.get('defaultValue')
+        self._selected_index = self._indexOfValue(selected_value)
+
+    @pyqtProperty(str, constant = True)
+    def parameterId(self) -> str:
+        return self._parameter_id
+
+    @pyqtProperty(str, constant = True)
+    def name(self) -> str:
+        return self._name
+
+    @pyqtProperty(list, constant = True)
+    def options(self) -> List[ConfigurationOption]:
+        return self._options
+
+    selectedIndexChanged = pyqtSignal()
+
+    def setSelectedIndex(self, selected_index: int) -> None:
+        if selected_index != self._selected_index and 0 <= selected_index < len(self._options):
+            self._selected_index = selected_index
+            self.selectedIndexChanged.emit()
+
+    @pyqtProperty(int, notify = selectedIndexChanged, fset = setSelectedIndex)
+    def selectedIndex(self) -> int:
+        return self._selected_index
+
+    @property
+    def selectedValue(self) -> str:
+        if 0 <= self._selected_index < len(self._options):
+            return self._options[self._selected_index].value
+        return ''
+
+    def _indexOfValue(self, value: Optional[str]) -> int:
+        for index, option in enumerate(self._options):
+            if option.value == value:
+                return index
+        return 0

--- a/src/model/DocumentsItem.py
+++ b/src/model/DocumentsItem.py
@@ -19,12 +19,13 @@ if TYPE_CHECKING:
 class DocumentsItem(QObject):
     """Represents an item in the documents tree to be displayed and interacted with on the UI"""
 
-    def __init__(self, node: "DocumentsTreeNode", api: "OnshapeApi", path: List[str]):
+    def __init__(self, node: "DocumentsTreeNode", api: "OnshapeApi", path: List[str], parent_model: "DocumentsModel"):
         super().__init__(parent = None)
         self._node: "DocumentsTreeNode" = node
         self._api: "OnshapeApi" = api
         self.element: "BaseElement" = self._node.element
         self._subModel: DocumentsModel = DocumentsModel(self._node, self._api, path)
+        self._parent_model: DocumentsModel = parent_model
         self._thumbnail_str_data: Optional[str] = None
         self._thumbnail_downloaded: bool = False
         self._selected: bool = False
@@ -71,6 +72,14 @@ class DocumentsItem(QObject):
     @pyqtProperty(bool, constant = True)
     def isDownloadable(self) -> bool:
         return self.element.is_downloadable
+
+    @pyqtProperty(bool, constant = True)
+    def hasConfigurationParameters(self) -> bool:
+        return self.isDownloadable and self._parent_model.hasConfigurationParameters
+
+    @pyqtProperty(list, constant = True)
+    def configurationParameters(self) -> list:
+        return self._parent_model.configurationParameters
 
     @pyqtProperty(str, constant = True)
     def shortDesc(self) -> str:

--- a/src/model/DocumentsModel.py
+++ b/src/model/DocumentsModel.py
@@ -6,6 +6,7 @@ from PyQt6.QtCore import pyqtProperty, pyqtSignal, pyqtSlot, QObject
 from PyQt6.QtNetwork import QNetworkRequest
 
 from ..data.Root import Root
+from .ConfigurationParameter import ConfigurationParameter
 
 if TYPE_CHECKING:
     from PyQt6.QtNetwork import QNetworkReply
@@ -24,6 +25,8 @@ class DocumentsModel(QObject):
         self._items: List["DocumentsItem"] = []
         self._path: List[str] = path + [self._node.element.name]
         self._load_error: Optional[str] = None
+        self._configuration_loaded: bool = False
+        self._configuration_parameters: List[ConfigurationParameter] = []
 
         if self.loaded:
             self._updateItems()
@@ -40,7 +43,7 @@ class DocumentsModel(QObject):
 
     def _updateItems(self) -> None:
         from .DocumentsItem import DocumentsItem
-        self._items = [DocumentsItem(child, self._api, self._path) for child in self._node.children]
+        self._items = [DocumentsItem(child, self._api, self._path, self) for child in self._node.children]
         self.elementsChanged.emit()
 
         for item in self._items:
@@ -51,6 +54,16 @@ class DocumentsModel(QObject):
     @pyqtProperty(bool, notify = elementsChanged)
     def loaded(self) -> bool:
         return self._node.children_loaded
+
+    configurationParametersChanged = pyqtSignal()
+
+    @pyqtProperty(list, notify = configurationParametersChanged)
+    def configurationParameters(self) -> List[ConfigurationParameter]:
+        return self._configuration_parameters
+
+    @pyqtProperty(bool, notify = configurationParametersChanged)
+    def hasConfigurationParameters(self) -> bool:
+        return len(self._configuration_parameters) > 0
 
     @pyqtProperty(bool, constant = True)
     def isRoot(self) -> bool:
@@ -68,6 +81,13 @@ class DocumentsModel(QObject):
 
     @pyqtSlot()
     def load(self) -> None:
+        if self._node.element.supports_configuration and not self._configuration_loaded:
+            self._loadConfiguration()
+            return
+
+        self._loadChildren()
+
+    def _loadChildren(self) -> None:
         def on_finished(children: List["DocumentsTreeNode"]):
             self._node.setChildren(children)
             self._updateItems()
@@ -80,7 +100,53 @@ class DocumentsModel(QObject):
             item.selected = False
 
         if not self.loaded:
-            self._node.element.loadChildren(self._api, on_finished, on_error)
+            self._node.element.loadChildren(self._api, self._buildConfigurationString(), on_finished, on_error)
+
+    def _loadConfiguration(self) -> None:
+        def on_finished(configuration: dict):
+            self._configuration_loaded = True
+            self._configuration_parameters = self._createConfigurationParameters(configuration)
+
+            for parameter in self._configuration_parameters:
+                parameter.selectedIndexChanged.connect(self._onConfigurationParameterChanged)
+
+            self.configurationParametersChanged.emit()
+            self._loadChildren()
+
+        def on_error(request: "QNetworkReply", error: "QNetworkReply.NetworkError"):
+            self._load_error = request.errorString() + bytes(request.readAll()).decode()
+            self.errorChanged.emit()
+
+        self._node.element.loadConfiguration(self._api, on_finished, on_error)
+
+    def _createConfigurationParameters(self, configuration: dict) -> List[ConfigurationParameter]:
+        current_values = {
+            parameter['parameterId']: parameter.get('value')
+            for parameter in configuration.get('currentConfiguration', [])
+            if 'parameterId' in parameter
+        }
+
+        return [
+            ConfigurationParameter(parameter, current_values.get(parameter['parameterId']))
+            for parameter in configuration.get('configurationParameters', [])
+            if 'parameterId' in parameter and len(parameter.get('options', [])) > 0
+               and parameter.get('isVisible', True)
+        ]
+
+    def _buildConfigurationString(self) -> Optional[str]:
+        values = [
+            f'{parameter.parameterId}={parameter.selectedValue}'
+            for parameter in self._configuration_parameters
+            if len(parameter.selectedValue) > 0
+        ]
+        return ';'.join(values) if len(values) > 0 else None
+
+    def _onConfigurationParameterChanged(self) -> None:
+        self._node.clear()
+        self._items = []
+        self.elementsChanged.emit()
+        self.selectedItemsChanged.emit()
+        self._loadChildren()
 
     @pyqtProperty(bool, constant = True)
     def refreshable(self) -> bool:
@@ -97,6 +163,9 @@ class DocumentsModel(QObject):
     @pyqtSlot()
     def refresh(self) -> None:
         self.clear()
+        self._configuration_loaded = False
+        self._configuration_parameters = []
+        self.configurationParametersChanged.emit()
         self.load()
 
     selectedItemsChanged = pyqtSignal()


### PR DESCRIPTION
## Summary
- Fetch Part Studio configuration metadata and expose enum-style configuration options in the part selector.
- Re-list parts using the selected Onshape configuration string.
- Pass the selected configuration through to STL export so imported parts match the visible selection.
- Add the configuration dropdown to each downloadable part row beside the thumbnail.

## Verification
- Ran `python -m compileall src` successfully using Python 3.
- Installed the modified plugin locally in Cura 5.13 and verified the configuration dropdown appears in the part selector UI.